### PR TITLE
Fix for Android: UTF-8 encoding

### DIFF
--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -561,22 +561,22 @@ public class Http extends Plugin {
       return url;
     }
   }
+  
+  private void writeToOutputStream(OutputStream out, String data) throws IOException {
+    try(DataOutputStream os = new DataOutputStream(out)){
+      os.write(data.getBytes(StandardCharsets.UTF_8));
+      os.flush();
+    }
+  }
 
-  private void setRequestBody(
-    HttpURLConnection conn,
-    JSObject data,
-    JSObject headers
-  )
-    throws IOException, JSONException {
+  private void setRequestBody(HttpURLConnection conn, JSObject data, JSObject headers) throws IOException, JSONException {
     String contentType = conn.getRequestProperty("Content-Type");
 
     if (contentType != null) {
       if (contentType.contains("application/json")) {
-        DataOutputStream os = new DataOutputStream(conn.getOutputStream());
-        os.writeBytes(data.toString());
-        os.flush();
-        os.close();
+        writeToOutputStream(conn.getOutputStream(), data.toString());
       } else if (contentType.contains("application/x-www-form-urlencoded")) {
+
         StringBuilder builder = new StringBuilder();
 
         Iterator<String> keys = data.keys();
@@ -584,19 +584,14 @@ public class Http extends Plugin {
           String key = keys.next();
           Object d = data.get(key);
           if (d != null) {
-            builder.append(
-              key + "=" + URLEncoder.encode(d.toString(), "UTF-8")
-            );
+            builder.append(key + "=" + URLEncoder.encode(d.toString(), "UTF-8"));
             if (keys.hasNext()) {
               builder.append("&");
             }
           }
         }
 
-        DataOutputStream os = new DataOutputStream(conn.getOutputStream());
-        os.writeBytes(builder.toString());
-        os.flush();
-        os.close();
+        writeToOutputStream(conn.getOutputStream(), builder.toString());
       } else if (contentType.contains("multipart/form-data")) {
         FormUploader uploader = new FormUploader(conn);
 

--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -569,7 +569,12 @@ public class Http extends Plugin {
     }
   }
 
-  private void setRequestBody(HttpURLConnection conn, JSObject data, JSObject headers) throws IOException, JSONException {
+  private void setRequestBody(
+    HttpURLConnection conn,
+    JSObject data,
+    JSObject headers
+  )
+    throws IOException, JSONException {
     String contentType = conn.getRequestProperty("Content-Type");
 
     if (contentType != null) {

--- a/android/src/main/java/com/getcapacitor/plugin/http/Http.java
+++ b/android/src/main/java/com/getcapacitor/plugin/http/Http.java
@@ -581,7 +581,6 @@ public class Http extends Plugin {
       if (contentType.contains("application/json")) {
         writeToOutputStream(conn.getOutputStream(), data.toString());
       } else if (contentType.contains("application/x-www-form-urlencoded")) {
-
         StringBuilder builder = new StringBuilder();
 
         Iterator<String> keys = data.keys();
@@ -589,7 +588,9 @@ public class Http extends Plugin {
           String key = keys.next();
           Object d = data.get(key);
           if (d != null) {
-            builder.append(key + "=" + URLEncoder.encode(d.toString(), "UTF-8"));
+            builder.append(
+              key + "=" + URLEncoder.encode(d.toString(), "UTF-8")
+            );
             if (keys.hasNext()) {
               builder.append("&");
             }


### PR DESCRIPTION
 I ran into an issue when using german umlauts (äöü) in json fields such as

`{
"name": "Jürgen"
}`

The submitted data was not properly UTF-8 encoded on android which resulted in an unparsable request on my server. Only android appears to be affected, the same request was properly encoded on iOS during my tests.